### PR TITLE
Fixes picker for RN 0.47

### DIFF
--- a/android/src/main/java/com/beefe/picker/PickerViewPackage.java
+++ b/android/src/main/java/com/beefe/picker/PickerViewPackage.java
@@ -21,7 +21,7 @@ public class PickerViewPackage implements ReactPackage {
         return Arrays.<NativeModule>asList(new PickerViewModule(reactContext));
     }
 
-    @Override
+    // Deprecated RN 0.47
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return  Collections.emptyList();
     }


### PR DESCRIPTION
I haven't checked if this works for react native versions before 0.47 yet. According to @radko93, this is backwards compatible. Let me know if anyone finds out otherwise.

Taken from @radko93's PR on the original repo.