### PR TITLE
Preserve visibility on enter background

### DIFF
--- a/android/src/main/java/com/beefe/picker/PickerViewModule.java
+++ b/android/src/main/java/com/beefe/picker/PickerViewModule.java
@@ -492,8 +492,7 @@ public class PickerViewModule extends ReactContextBaseJavaModule implements Life
 
     @Override
     public void onHostPause() {
-        hide();
-        dialog = null;
+
     }
 
     @Override


### PR DESCRIPTION
Fixes issue where picker hides when the app leaves the foreground. This behavior differs from the default iOS behavior. It also causes bugs due to the app loosing the visibility state of the picker.

|Before|After|
|-|-|
|![tumble_picker_hide_bug](https://user-images.githubusercontent.com/410463/30939048-2e9278ee-a3aa-11e7-9ea6-725838ccd086.gif)|![tumble_picker_hide_fix](https://user-images.githubusercontent.com/410463/30939061-36e2628e-a3aa-11e7-9e5f-8a8b0898dedd.gif)|

