### PR TITLE
[Picker] Fix Android Crash

### DIFF
--- a/android/src/main/java/com/beefe/picker/PickerViewModule.java
+++ b/android/src/main/java/com/beefe/picker/PickerViewModule.java
@@ -383,7 +383,7 @@ public class PickerViewModule extends ReactContextBaseJavaModule implements Life
         if (dialog == null) {
             return;
         }
-        if (!dialog.isShowing()) {
+        if (!dialog.isShowing() && !getCurrentActivity().isFinishing()) {
             dialog.show();
         }
     }


### PR DESCRIPTION
Upon testing release today, I [noticed a common android crash](https://sentry.io/organizations/root-insurance/issues/1238582131/?environment=staging&project=1507317&query=is%3Aunresolved) which is caused by a race condition in which either an activity had not loaded in yet or is unmounting. In this case, a dialog cannot be shown, yet this picker component attempts to show the dialog anyway.

Upon researching the issue, I found [multiple](https://stackoverflow.com/questions/9529504/unable-to-add-window-token-android-os-binderproxy-is-not-valid-is-your-activ) [stackoverflow](https://stackoverflow.com/questions/7811993/error-binderproxy45d459c0-is-not-valid-is-your-activity-running) links with a solution which checks whether the activity is eligible to show a dialog or not. I have implemented this fix.

This is my preliminary fix. I require knowledge on how to test my fix in order to be able to merge this PR.